### PR TITLE
fix: loading of config file in a json format

### DIFF
--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -82,7 +82,7 @@ async function main() {
       return;
     }
 
-    const testsDir = config.testDir;
+    const testsDir = path.resolve(Global.getCwd(), config.testDir);
     const parallel = config.parallel;
 
     const testFileMatcher = /.*\.test\.(m|c){0,1}(ts|js|tsx|jsx)$/;

--- a/src/base/utils/config.ts
+++ b/src/base/utils/config.ts
@@ -77,7 +77,7 @@ export async function loadConfig(vargs: string[], options: TestRunnerOptions) {
   const files = await _readdir(Global.getCwd());
 
   const jsTypeConfig = files.find((filename) =>
-    /gest\.config\.(js|mjs)/i.test(filename)
+    /gest\.config\.(js|mjs)$/i.test(filename)
   );
 
   if (jsTypeConfig) {


### PR DESCRIPTION
Previous release unintentionally broke loading `gest.config.json` files. This is fixed now.