### PR TITLE
feat: added option that will silence all logs within the test files

### DIFF
--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -50,6 +50,7 @@ async function main() {
           <line>-f, --file [path]</line>
           <line>-t, --testNamePattern [regex]</line>
           <line>-p, --testPathPattern [regex]</line>
+          <line>-s, --silenceLogs</line>
         </pad>
       `);
 
@@ -59,6 +60,7 @@ async function main() {
     const fileArg = _getArgValue(pargs, "-f", "--file");
     const testNamePattern = _getArgValue(pargs, "-t", "--testNamePattern");
     const testFilePattern = _getArgValue(pargs, "-p", "--testPathPattern");
+    const silenceLogs = pargs.includes("-s") || pargs.includes("--silenceLogs");
 
     const options: TestRunnerOptions = {
       verbose: pargs.includes("--verbose") || pargs.includes("-v"),
@@ -167,7 +169,9 @@ async function main() {
 
     await progressTracker.flush();
 
-    ConsoleInterceptor.printCollectedLogs(consoleInterceptor);
+    if (!silenceLogs) {
+      ConsoleInterceptor.printCollectedLogs(consoleInterceptor);
+    }
 
     Output.print("");
 


### PR DESCRIPTION
A new cli argument has been added: `-s` or `--silenceLogs`. When passed to the gest all logs emitted from within tests will be silenced.