### PR TITLE
fix: proper comparison of arrays

### DIFF
--- a/src/user-land/utils/validators.ts
+++ b/src/user-land/utils/validators.ts
@@ -29,6 +29,32 @@ export function deepEqual(a: any, b: any): EqualityCheck {
     };
   }
 
+  if (Array.isArray(a) && Array.isArray(b)) {
+    const lastAIndex = a.length - 1;
+    for (const bIndex of b.keys()) {
+      if (bIndex > lastAIndex) {
+        return {
+          isEqual: false,
+          expected: b[bIndex],
+          received: undefined,
+        };
+      }
+
+      const aItem = a[bIndex];
+      const bItem = b[bIndex];
+
+      const result = deepEqual(aItem, bItem);
+
+      if (!result.isEqual) {
+        return result;
+      }
+    }
+
+    return {
+      isEqual: true,
+    };
+  }
+
   if (a instanceof Date && b instanceof Date) {
     return {
       isEqual: a.valueOf() === b.valueOf(),
@@ -191,6 +217,32 @@ export function matchValues(a: any, b: any): EqualityCheck {
       isEqual: false,
       expected: b,
       received: a,
+    };
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    const lastAIndex = a.length - 1;
+    for (const bIndex of b.keys()) {
+      if (bIndex > lastAIndex) {
+        return {
+          isEqual: false,
+          expected: b[bIndex],
+          received: undefined,
+        };
+      }
+
+      const aItem = a[bIndex];
+      const bItem = b[bIndex];
+
+      const result = matchValues(aItem, bItem);
+
+      if (!result.isEqual) {
+        return result;
+      }
+    }
+
+    return {
+      isEqual: true,
     };
   }
 


### PR DESCRIPTION
Comparison methods up till now did not handle arrays properly, each array was being treated as a regular object and each enumerable property on those was being compared.