### PR TITLE
feat: added option to skip a single unit test in code

### DIFF
--- a/src/user-land/index.ts
+++ b/src/user-land/index.ts
@@ -23,6 +23,16 @@ export const it = (name: string, fn: () => any) => {
   });
 };
 
+export const skip = (name: string, fn: () => any) => {
+  TestCollector.addIt({
+    name,
+    line: 0,
+    column: 0,
+    skip: true,
+    callback: () => {},
+  });
+};
+
 export const beforeAll = (fn: () => void) => {
   // Get line where this function was called
   const [line, column] = _getLineFromError(new Error());

--- a/src/user-land/test-collector.ts
+++ b/src/user-land/test-collector.ts
@@ -2,6 +2,7 @@ export type It = {
   name: string;
   line: number;
   column: number;
+  skip?: boolean;
   callback: () => any;
 };
 


### PR DESCRIPTION
new function available in tests: `skip()` which can be used instead of `it()`, tests declared with `skip()` will not be ran and will show as skipped in the report.

Additionally `beforeEach` and `afterEach` hooks will now always be skipped along with the individual tests. Before those hooks could be ran before a test that was skipped.