### PR TITLE
feat: added FakeTimers feature

### DIFF
--- a/src/base/builder/build-file.ts
+++ b/src/base/builder/build-file.ts
@@ -39,6 +39,14 @@ export async function _buildFile(params: {
             ];
         })
       ),
+      setTimeout: {
+        kind: "identifier",
+        value: "__gest_timers.setTimeout",
+      },
+      setInterval: {
+        kind: "identifier",
+        value: "__gest_timers.setInterval",
+      },
       console: {
         kind: "identifier",
         value: "__gest_console",

--- a/src/base/builder/esbuild-script.ts
+++ b/src/base/builder/esbuild-script.ts
@@ -1,5 +1,6 @@
 import { OptionalField, Type, createValidatedFunction } from "dilswer";
 import esbuild from "esbuild";
+import fs from "fs/promises";
 import path from "path";
 import * as url from "url";
 import type { BuildScriptMessage } from "./build-script-message";
@@ -230,6 +231,14 @@ async function main() {
         },
       ],
     });
+
+    const out = await fs.readFile(msg.output, "utf-8");
+    const injects = await fs.readFile(
+      path.join(__dirname, "injects.mjs"),
+      "utf-8"
+    );
+
+    await fs.writeFile(msg.output, injects + "\n" + out, "utf-8");
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/src/base/builder/injects.ts
+++ b/src/base/builder/injects.ts
@@ -1,0 +1,88 @@
+/**
+ * Contents of this file will be injected into each transformed
+ * test file. Hence every variable defined here will be globally
+ * available within the scope of the test file bundle.
+ */
+
+import type { FakeTimerRegistry } from "../utils/timers";
+
+const __noop = (...args: any[]) => {};
+
+const __gest_timers = {
+  setTimeout: __noop as any as typeof setTimeout,
+  setInterval: __noop as any as typeof setInterval,
+  useFakeTimers: false,
+  timeoutRegistry: null as FakeTimerRegistry | null,
+  intervalRegistry: null as FakeTimerRegistry | null,
+};
+
+(() => {
+  const global = globalThis;
+
+  __gest_timers.setTimeout =
+    typeof __gest_originalSetTimeout !== "undefined"
+      ? __gest_originalSetTimeout
+      : global.setTimeout.bind(null);
+
+  __gest_timers.setInterval =
+    typeof __gest_originalSetInterval !== "undefined"
+      ? __gest_originalSetInterval
+      : global.setInterval.bind(null);
+})();
+
+if (typeof __gest_getSetTimeout !== "undefined") {
+  __gest_getSetTimeout(__gest_timers);
+}
+
+if (typeof __gest_getSetInterval !== "undefined") {
+  __gest_getSetInterval(__gest_timers);
+}
+
+class FakeTimers {
+  static get originalSetTimeout() {
+    const global = globalThis;
+    return (
+      typeof __gest_originalSetTimeout !== "undefined"
+        ? __gest_originalSetTimeout
+        : global.setTimeout
+    ).bind(null);
+  }
+
+  static enable() {
+    __gest_timers.useFakeTimers = true;
+  }
+
+  static disable() {
+    __gest_timers.useFakeTimers = false;
+    __gest_timers.timeoutRegistry?.clear();
+  }
+
+  static runAll() {
+    __gest_timers.timeoutRegistry?.runAll();
+  }
+
+  static runNext(args?: any[]): any {
+    return __gest_timers.timeoutRegistry?.runNext(args);
+  }
+
+  /**
+   * Check if any timeout is currently waiting to be started.
+   * Optionally check if a specific number of timeouts are
+   * waiting.
+   */
+  static isTimeoutStarted(times?: number) {
+    const c = __gest_timers.timeoutRegistry?.count() ?? 0;
+
+    if (times != null) {
+      return c === times;
+    } else {
+      return c > 0;
+    }
+  }
+}
+
+// prevent bundler from removing unused variables
+__noop(FakeTimers);
+
+export type { FakeTimers };
+export type GestTimers = typeof __gest_timers;

--- a/src/base/globals.ts
+++ b/src/base/globals.ts
@@ -1,6 +1,7 @@
 export class Global {
   private static cwd?: string;
   private static tmpDir?: string;
+  private static sourceMapLineOffset?: number;
 
   public static getCwd(): string {
     if (!this.cwd) {
@@ -24,5 +25,17 @@ export class Global {
 
   public static setTmpDir(tmpDir: string): void {
     this.tmpDir = tmpDir;
+  }
+
+  public static getSourceMapLineOffset(): number {
+    if (!this.sourceMapLineOffset) {
+      throw new Error("Source map offset not set.");
+    }
+
+    return this.sourceMapLineOffset;
+  }
+
+  public static setSourceMapLineOffset(offset: number): void {
+    this.sourceMapLineOffset = offset;
   }
 }

--- a/src/base/progress/progress-utils/suite-progress.ts
+++ b/src/base/progress/progress-utils/suite-progress.ts
@@ -58,7 +58,10 @@ export class SuiteProgress {
   }
 
   private getHookLink(sourceMap: SourceMapReader, hook: TestHook) {
-    const hookLocation = sourceMap.getOriginalPosition(hook.line, hook.column);
+    const hookLocation = sourceMap.getOriginalPosition(
+      hook.line - Global.getSourceMapLineOffset(),
+      hook.column
+    );
 
     if (hookLocation == null) return undefined;
 

--- a/src/base/progress/progress-utils/unit-progress.ts
+++ b/src/base/progress/progress-utils/unit-progress.ts
@@ -1,4 +1,5 @@
 import type { It } from "../../../user-land/test-collector";
+import { Global } from "../../globals";
 import type { SourceMapReader } from "../../sourcemaps/reader";
 import type { ConfigFacade } from "../../utils/config";
 import {
@@ -61,7 +62,7 @@ export class UnitProgress {
     if (this.unit == null || !sourceMap) return undefined;
 
     const unitLocation = sourceMap.getOriginalPosition(
-      this.unit.line,
+      this.unit.line - Global.getSourceMapLineOffset(),
       this.unit.column
     );
 
@@ -80,7 +81,7 @@ export class UnitProgress {
     if (!_isExpectError(this.error.thrown)) return suiteFilepath;
 
     const expectLocation = sourceMap.getOriginalPosition(
-      this.error.thrown.line,
+      this.error.thrown.line - Global.getSourceMapLineOffset(),
       this.error.thrown.column
     );
 

--- a/src/base/sourcemaps/vlq.ts
+++ b/src/base/sourcemaps/vlq.ts
@@ -1,4 +1,4 @@
-type Segment =
+export type Segment =
   | [
       outColumn: number,
       file: number,

--- a/src/base/utils/deep-copy.ts
+++ b/src/base/utils/deep-copy.ts
@@ -20,6 +20,8 @@ export const deepCopy = <T>(obj: T, visited = new Map<any, any>()): T => {
 
   const copy: Record<any, any> = {};
 
+  Object.setPrototypeOf(copy, Object.getPrototypeOf(obj));
+
   visited.set(obj, copy);
 
   for (const key of keys) {
@@ -30,6 +32,11 @@ export const deepCopy = <T>(obj: T, visited = new Map<any, any>()): T => {
 
   if (orgProto != null) {
     Object.setPrototypeOf(copy, orgProto);
+  }
+
+  if (obj instanceof Error) {
+    copy.stack = obj.stack;
+    copy.message = obj.message;
   }
 
   return copy as T;

--- a/src/base/utils/errors/error-handling.ts
+++ b/src/base/utils/errors/error-handling.ts
@@ -1,4 +1,5 @@
 import type { ExpectError } from "../../../user-land";
+import { Global } from "../../globals";
 import type { SourceMapReader } from "../../sourcemaps/reader";
 import type { ConfigFacade } from "../config";
 import type { ParsedStack } from "../error-stack-parser-type";
@@ -56,7 +57,7 @@ export function _getErrorStack(
 
         if (stackItem.line != null && stackItem.column != null) {
           const mapped = sourceMap.getOriginalPosition(
-            Number(stackItem.line),
+            Number(stackItem.line) - Global.getSourceMapLineOffset(),
             Number(stackItem.column)
           );
 

--- a/src/base/utils/timers.ts
+++ b/src/base/utils/timers.ts
@@ -1,0 +1,176 @@
+import GLib from "gi://GLib?version=2.0";
+import { padLeftLines } from "../../user-land/utils/pad-left-lines";
+import type { GestTimers } from "../builder/injects";
+import type { ConsoleInterceptor } from "./console-interceptor/console-interceptor";
+
+class Timer {
+  constructor(
+    private id: number,
+    private callback: (...args: any[]) => any,
+    public readonly targetTime: number,
+    private defaultArgs: any[]
+  ) {}
+
+  is(id: number) {
+    return this.id === id;
+  }
+
+  getID() {
+    return this.id;
+  }
+
+  run(args?: any[]) {
+    return this.callback(...(args ?? this.defaultArgs));
+  }
+}
+
+export class FakeTimerRegistry {
+  private nextId = 1;
+  private timers: Array<Timer> = [];
+
+  private lastGivenMillisecond = 0;
+  private getMillisecond() {
+    let result = GLib.get_monotonic_time() / 1000;
+
+    if (result <= this.lastGivenMillisecond) {
+      result = this.lastGivenMillisecond + 1;
+    }
+
+    this.lastGivenMillisecond = result;
+
+    return result;
+  }
+
+  private generateID() {
+    return this.nextId++;
+  }
+
+  /** Sorts timer by the target time in descending order. */
+  private sortTimers() {
+    const sortFn = (a: Timer, b: Timer) => {
+      return a.targetTime - b.targetTime;
+    };
+    this.timers.sort(sortFn);
+  }
+
+  public clear() {
+    this.timers = [];
+  }
+
+  public count() {
+    return this.timers.length;
+  }
+
+  public addTimeout(
+    callback: (...args: any[]) => any,
+    ms: number | undefined,
+    args: any[]
+  ) {
+    const currentMillisecond = this.getMillisecond();
+    const targetTime = currentMillisecond + (ms ?? 0);
+
+    const timer = new Timer(this.generateID(), callback, targetTime, args);
+    this.timers.push(timer);
+    this.sortTimers();
+    return timer;
+  }
+
+  public cancelTimeout(id: number) {
+    this.timers = this.timers.filter((t) => !t.is(id));
+  }
+
+  public runAll() {
+    const allTimers = this.timers;
+    this.timers = [];
+
+    for (const timer of allTimers) {
+      try {
+        timer.run();
+      } catch (e) {
+        //
+      }
+    }
+  }
+
+  public runNext(args?: any[]) {
+    const timer = this.timers.shift();
+
+    if (timer) {
+      return timer.run(args);
+    }
+  }
+}
+
+export const initFakeTimers = (console: ConsoleInterceptor) => {
+  const originalSetTimeout = setTimeout;
+  const originalSetInterval = setInterval;
+
+  const __gest_getSetTimeout = (container: GestTimers) => {
+    const fakeTimerRegistry = new FakeTimerRegistry();
+
+    Object.assign(container, {
+      timeoutRegistry: fakeTimerRegistry,
+      setTimeout(
+        callback: (...args: any[]) => any,
+        ms?: number,
+        ...args: any[]
+      ) {
+        const error = new Error();
+
+        const handleError = (err: any) => {
+          console.error(
+            "Exception raised in a timeout callback:",
+            err,
+            "\nThe above error was raised in this 'setTimeout':",
+            error.stack && "\n  " + padLeftLines(error.stack, " ", 2)
+          );
+        };
+
+        const fn = (...fnArgs: any[]) => {
+          try {
+            const result = callback.apply(null, fnArgs);
+
+            if (result && result instanceof Promise) {
+              return result.catch(handleError);
+            }
+            return result;
+          } catch (err) {
+            handleError(err);
+          }
+        };
+
+        if (container.useFakeTimers) {
+          return fakeTimerRegistry.addTimeout(fn, ms, args).getID();
+        } else {
+          const id = setTimeout(fn, ms, ...args);
+          return id;
+        }
+      },
+    });
+  };
+
+  Object.defineProperty(globalThis, "__gest_getSetTimeout", {
+    value: __gest_getSetTimeout,
+  });
+
+  Object.defineProperty(globalThis, "__gest_originalSetTimeout", {
+    value: originalSetTimeout,
+  });
+
+  Object.defineProperty(globalThis, "__gest_originalSetInterval", {
+    value: originalSetInterval,
+  });
+};
+
+declare global {
+  const __gest_getSetTimeout:
+    | undefined
+    | ((container: { setTimeout: typeof setTimeout }) => void);
+
+  const __gest_getSetInterval:
+    | undefined
+    | ((container: { setInterval: typeof setInterval }) => void);
+
+  const __gest_originalSetTimeout: typeof setTimeout | undefined;
+  const __gest_originalSetInterval: typeof setInterval | undefined;
+}

--- a/src/user-land/index.ts
+++ b/src/user-land/index.ts
@@ -1,3 +1,4 @@
+import type { FakeTimers as FT } from "../base/builder/injects";
 import type { CalledFrom, Matcher, MatcherResultHandlers } from "./matchers";
 import { Matchers } from "./matchers";
 import type { Test } from "./test-collector";
@@ -97,7 +98,7 @@ export class ExpectError extends Error {
   }
 
   private detectUnhandled() {
-    this.timeoutId = setTimeout(() => {
+    this.timeoutId = FakeTimers.originalSetTimeout(() => {
       // TODO: communicate with the monitor
       console.error(
         `An expect error was not handled. This is most likely due to an async matcher not being awaited.\n\nError: ${this.message}`
@@ -143,6 +144,12 @@ export const expect = (value: any) => {
 export const defineMatcher = (matcherName: string, matcher: Matcher) => {
   Matchers.add(matcherName, matcher);
 };
+
+// Fake Timers
+
+declare global {
+  const FakeTimers: typeof FT;
+}
 
 // Default matchers
 


### PR DESCRIPTION
Added fake timers. To use fake timers use the global variable that globally available in all tests - `FakeTimers`.

**Example**

```ts
export default describe("FakeTimers test", () => {
  it("timers are disabled in this test", () => {
    FakeTimers.enable();
    
    let wasCalled = false;

    const onTimeout = () => {
      wasCalled = true;
    }
    setTimeout(onTimeout); // will never run until manually triggered

    wasCalled; // false

    FakeTimers.runNext(); // trigger, will invoke the `onTimeout` callback

    wasCalled; // true

    FakeTimers.disable(); // remember to disable fake timers once the test ends
  })
})
```