### PR TITLE
fix: prevent async describes by throwing errors when detected

### DIFF
--- a/src/base/progress/progress-utils/unit-progress.ts
+++ b/src/base/progress/progress-utils/unit-progress.ts
@@ -1,4 +1,4 @@
-import type { It } from "../../../user-land/test-collector";
+import type { Test } from "../../../user-land/test-collector";
 import { Global } from "../../globals";
 import type { SourceMapReader } from "../../sourcemaps/reader";
 import type { ConfigFacade } from "../../utils/config";
@@ -21,7 +21,7 @@ export interface UnitProgressInitParams {
   error?: ProgressErrorReport;
   timedOut?: boolean;
   skipped?: boolean;
-  unit?: It;
+  unit?: Test;
 }
 
 export type UnitErrorReport = ProgressErrorReportParsed & {
@@ -48,7 +48,7 @@ export class UnitProgress {
   error?: ProgressErrorReport;
   timedOut?: boolean;
   skipped?: boolean;
-  unit?: It;
+  unit?: Test;
 
   constructor(
     private parent: SuiteProgress,

--- a/src/user-land/index.ts
+++ b/src/user-land/index.ts
@@ -1,16 +1,16 @@
 import type { FakeTimers as FT } from "../base/builder/injects";
 import type { CalledFrom, Matcher, MatcherResultHandlers } from "./matchers";
 import { Matchers } from "./matchers";
-import type { Test } from "./test-collector";
+import type { Describe } from "./test-collector";
 import { TestCollector } from "./test-collector";
 import { FunctionMockRegistry, createMock } from "./utils/function-mocks";
 import { _getLineFromError } from "./utils/parse-error";
 
-export const describe = (name: string, fn: () => void): Test => {
+export const describe = (name: string, fn: () => void): Describe => {
   // Get line where this function was called
   const [line, column] = _getLineFromError(new Error());
 
-  return TestCollector.collectSubTest(name, line, column, fn);
+  return TestCollector.collectDescribes(name, line, column, fn);
 };
 
 export const it = (name: string, fn: () => any) => {
@@ -24,6 +24,8 @@ export const it = (name: string, fn: () => any) => {
     callback: fn,
   });
 };
+
+export const test = it;
 
 export const skip = (name: string, fn: () => any) => {
   TestCollector.addIt({


### PR DESCRIPTION
Before, passing asynchronous function into `describe()` would not raise any errors or warnings and the test would pass successfully even if some tests have been omitted because of a race condition. This has now been fixed, if the function given to `describe()` is detected to be asynchronous, error will be thrown and the whole Test Suite will not be run.