### PR TITLE
feat: test context

### DIFF
--- a/src/base/utils/errors/error-handling.ts
+++ b/src/base/utils/errors/error-handling.ts
@@ -1,12 +1,24 @@
-import type { ExpectError } from "../../../user-land";
+import type {
+  DeferedTaskError,
+  ExpectError,
+  GestTestError,
+} from "../../../user-land/utils/errors";
 import { Global } from "../../globals";
 import type { SourceMapReader } from "../../sourcemaps/reader";
 import type { ConfigFacade } from "../config";
 import type { ParsedStack } from "../error-stack-parser-type";
 import { parseErrorStack } from "./stack-parser";
 
+export function _isGestTestError(e: any): e is GestTestError {
+  return e && typeof e === "object" && "_isGestError" in e;
+}
+
 export function _isExpectError(e: any): e is ExpectError {
   return e && typeof e === "object" && e.name === "ExpectError";
+}
+
+export function _isDeferedError(e: any): e is DeferedTaskError {
+  return e && typeof e === "object" && e.name === "DeferedTaskError";
 }
 
 export function _getErrorMessage(e: unknown) {

--- a/src/user-land/matchers.ts
+++ b/src/user-land/matchers.ts
@@ -1,3 +1,4 @@
+import type { FileLocation } from "./utils/errors";
 import { FunctionMock } from "./utils/function-mocks";
 import { diff } from "./utils/json-diff";
 import { _getLineFromError } from "./utils/parse-error";
@@ -187,21 +188,16 @@ export type Matcher = (
   matcherArgs: any[]
 ) => MatcherResult | Promise<MatcherResult>;
 
-export type CalledFrom = {
-  line: number;
-  column: number;
-};
-
 export type MatcherResultHandlers = {
   sync: (
     result: MatcherResult,
     negate: boolean,
-    celledFrom: CalledFrom
+    celledFrom: FileLocation
   ) => void;
   async: (
     result: Promise<MatcherResult>,
     negate: boolean,
-    celledFrom: CalledFrom
+    celledFrom: FileLocation
   ) => Promise<void>;
 };
 
@@ -239,7 +235,7 @@ export class Matchers {
 
           return (...args: any[]) => {
             // Get line where this function was called
-            const [line, column] = _getLineFromError(new Error());
+            const { column, line } = _getLineFromError(new Error());
 
             const calledFrom = {
               line,

--- a/src/user-land/test-collector.ts
+++ b/src/user-land/test-collector.ts
@@ -1,9 +1,14 @@
+export type InternalTestContext = {
+  fullTitle: string;
+  reportError: (err: any) => void;
+};
+
 export type Test = {
   name: string;
   line: number;
   column: number;
   skip?: boolean;
-  callback: () => any;
+  callback: (info: InternalTestContext) => any;
 };
 
 export type TestHook = {

--- a/src/user-land/test-context.ts
+++ b/src/user-land/test-context.ts
@@ -1,0 +1,98 @@
+import type { InternalTestContext } from "./test-collector";
+import { DeferedTaskError, GestTestError } from "./utils/errors";
+import { _getLineFromError } from "./utils/parse-error";
+
+export type TestContext = {
+  /**
+   * Title of the test unit, the same value as given to the `it`
+   * function.
+   */
+  title: string;
+  /**
+   * The full title of the test unit, including the titles of the
+   * parent describe blocks.
+   */
+  fullTitle: string;
+  /**
+   * Defer is where you can put the teardown logic for your test.
+   * Every deferred function will run after the test has
+   * finished, regardless of whether it has passed or failed.
+   *
+   * If a deferred function fails, the test will fail as well.
+   */
+  defer(task: () => any): void;
+  /**
+   * Logs an error to the console with a mapped stack trace.
+   * Logging an error will cause the test to fail.
+   */
+  logError(err: any): void;
+};
+
+type DeferredTask = { action: () => any; line: number; column: number };
+
+export const testCallback = (
+  title: string,
+  fn: (context: TestContext) => any
+) => {
+  const deferredTasks: Array<DeferredTask> = [];
+
+  const runDeferred = async (err: unknown, _context: InternalTestContext) => {
+    const errors: {
+      line: number;
+      column: number;
+      thrown: any;
+    }[] = [];
+
+    for (const task of deferredTasks) {
+      try {
+        await task.action();
+      } catch (e) {
+        errors.push({
+          line: task.line,
+          column: task.column,
+          thrown: e,
+        });
+      }
+    }
+
+    if (err) {
+      if (errors.length > 0) {
+        _context.reportError(new DeferedTaskError(errors));
+      }
+
+      throw err;
+    }
+
+    if (errors.length > 0) {
+      throw new DeferedTaskError(errors);
+    }
+  };
+
+  return async (_context: InternalTestContext) => {
+    const ctx: TestContext = {
+      title,
+      fullTitle: _context.fullTitle,
+      defer(action) {
+        const { column, line } = _getLineFromError(new Error());
+        deferredTasks.push({
+          action,
+          column,
+          line,
+        });
+      },
+      logError(err) {
+        const location = _getLineFromError(new Error());
+        _context.reportError(GestTestError.from(err, location));
+      },
+    };
+
+    let err: any = undefined;
+    try {
+      await fn(ctx);
+    } catch (e) {
+      err = e;
+    }
+
+    return await runDeferred(err, _context);
+  };
+};

--- a/src/user-land/utils/errors.ts
+++ b/src/user-land/utils/errors.ts
@@ -1,0 +1,86 @@
+import { _getLineFromError } from "./parse-error";
+
+export type FileLocation = {
+  line: number;
+  column: number;
+};
+
+export class GestTestError extends Error {
+  static from(err: unknown, location?: FileLocation) {
+    let msg = "Unknown error";
+    let stack: string | undefined = undefined;
+
+    if (err instanceof Error) {
+      msg = err.message;
+      stack = err.stack;
+    }
+
+    const gestError = new GestTestError(msg, location);
+
+    if (stack) {
+      gestError.stack = stack;
+    }
+
+    return gestError;
+  }
+
+  public _isGestError = true;
+  public line: number;
+  public column: number;
+
+  constructor(message: string, location?: FileLocation) {
+    super(message);
+    this.name = "GestError";
+
+    if (location) {
+      this.line = location.line;
+      this.column = location.column;
+    } else {
+      const { column, line } = _getLineFromError(this);
+      this.line = line;
+      this.column = column;
+    }
+  }
+}
+
+export class ExpectError extends GestTestError {
+  private timeoutId?: NodeJS.Timeout;
+
+  constructor(
+    message: string,
+    public readonly expected: string | undefined,
+    public readonly received: string | undefined,
+    public readonly diff: string | undefined,
+    location: FileLocation
+  ) {
+    super(message, location);
+    this.name = "ExpectError";
+    this.detectUnhandled();
+  }
+
+  private detectUnhandled() {
+    this.timeoutId = FakeTimers.originalSetTimeout(() => {
+      // TODO: communicate with the monitor
+      console.error(
+        `An expect error was not handled. This is most likely due to an async matcher not being awaited.\n\nError: ${this.message}`
+      );
+    }, 100);
+  }
+
+  handle() {
+    clearTimeout(this.timeoutId);
+  }
+}
+
+type DeferredErrorInfo = {
+  line: number;
+  column: number;
+  thrown: any;
+};
+
+export class DeferedTaskError extends GestTestError {
+  constructor(public errors: DeferredErrorInfo[]) {
+    super("Deferred task(s) has failed.");
+    this.name = "DeferedTaskError";
+  }
+}

--- a/src/user-land/utils/parse-error.ts
+++ b/src/user-land/utils/parse-error.ts
@@ -1,3 +1,5 @@
+import type { FileLocation } from "./errors";
+
 export const _toNumber = (value: string | number | undefined, def: number) => {
   if (value === undefined) {
     return def;
@@ -14,9 +16,12 @@ export const _toNumber = (value: string | number | undefined, def: number) => {
   }
 };
 
-export const _getLineFromError = (error: Error): [number, number] => {
+export const _getLineFromError = (error: Error): FileLocation => {
   const stack = error.stack;
   const secondLine = stack?.split("\n")[1];
   const [line, column] = secondLine?.split(":").splice(-2) ?? [];
-  return [_toNumber(line, 0), _toNumber(column, 0)];
+  return {
+    line: _toNumber(line, 0),
+    column: _toNumber(column, 0),
+  };
 };

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,9 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "rootDirs": [".", "../src"]
+        "rootDir": "../"
     },
-    "include": ["./**/*.ts"]
+    "include": [
+        "./**/*.ts"
+    ]
 }


### PR DESCRIPTION
Added a context object that is available to all unit tests, to access it simply add an argument to the function passed to the `it`. At this moment context will give access to the title of the test, and two helper methods: `defer()` - which can be used to add teardown logic to the test and `logError()` which will log errors similarly to how it's done with the errors thrown from the `it` blocks.

### Example

```ts
export default describe("myTest", () => {
  it("this is how you use context", (ctx) => {
    ctx.title; // "this is how you use context"
    ctx.fullTitle; // "myTest > this is how you use context"
    ctx.defer(() => {/* cleanup */});
    ctx.logError(new Error("oh no!"));
  })
})
``` 