### PR TITLE
feat: extended support for fake timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "devDependencies": {
     "@ncpa0cpl/nodepack": "^2.1.2",
-    "@reactgjs/gest": "0.1.1",
+    "@reactgjs/gest": "0.3.2",
     "@types/node": "^18.15.12",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
@@ -77,6 +77,6 @@
   },
   "resolutions": {
     "dilswer": "2.1.1",
-    "@reactgjs/gest": "0.1.1"
+    "@reactgjs/gest": "0.3.2"
   }
 }

--- a/src/base/utils/timers.ts
+++ b/src/base/utils/timers.ts
@@ -5,11 +5,20 @@ import type { ConsoleInterceptor } from "./console-interceptor/console-intercept
 
 class Timer {
   constructor(
-    private id: number,
-    private callback: (...args: any[]) => any,
-    public readonly targetTime: number,
-    private defaultArgs: any[]
+    protected register: FakeTimerRegistry,
+    protected id: number,
+    protected callback: (...args: any[]) => any,
+    protected targetTime: number,
+    protected defaultArgs: any[]
   ) {}
+
+  changeTargetTime(targetTime: number) {
+    this.targetTime = targetTime;
+  }
+
+  getTargetTime() {
+    return this.targetTime;
+  }
 
   is(id: number) {
     return this.id === id;
@@ -22,13 +31,50 @@ class Timer {
   run(args?: any[]) {
     return this.callback(...(args ?? this.defaultArgs));
   }
+
+  valueOf() {
+    return this.targetTime;
+  }
 }
+
+class Interval extends Timer {
+  constructor(
+    register: FakeTimerRegistry,
+    id: number,
+    callback: (...args: any[]) => any,
+    protected ms: number,
+    defaultArgs: any[]
+  ) {
+    super(register, id, callback, register.now() + ms, defaultArgs);
+  }
+
+  run(...args: any[]) {
+    this.changeTargetTime(this.targetTime + this.ms);
+    this.register["sortIntervals"]();
+    return super.run(...args);
+  }
+}
+
+const compareTimers = (a: Timer, b: Timer) => {
+  return a > b ? 1 : -1;
+};
+
+const attempt = (fn: () => any) => {
+  try {
+    return fn();
+  } catch (e) {
+    //
+  }
+};
 
 export class FakeTimerRegistry {
   private nextId = 1;
   private timers: Array<Timer> = [];
-
+  private intervals: Array<Interval> = [];
+  private currentFakeTime: null | number = null;
   private lastGivenMillisecond = 0;
+  public isUsingFakeTime = false;
+
   private getMillisecond() {
     let result = GLib.get_monotonic_time() / 1000;
 
@@ -47,18 +93,74 @@ export class FakeTimerRegistry {
 
   /** Sorts timer by the target time in descending order. */
   private sortTimers() {
-    const sortFn = (a: Timer, b: Timer) => {
-      return a.targetTime - b.targetTime;
-    };
-    this.timers.sort(sortFn);
+    this.timers.sort(compareTimers);
+  }
+
+  /** Sorts timer by the target time in descending order. */
+  private sortIntervals() {
+    this.intervals.sort(compareTimers);
+  }
+
+  private getNext() {
+    const nextTimer = this.timers[0];
+    const nextInterval = this.intervals[0];
+
+    if (!nextTimer) {
+      return {
+        next: nextInterval,
+        remove: () => {},
+      };
+    }
+
+    if (!nextInterval) {
+      return {
+        next: nextTimer,
+        remove: () => {
+          this.timers.shift();
+        },
+      };
+    }
+
+    if (this.timers[0]! > this.intervals[0]!) {
+      return {
+        next: nextInterval,
+        remove: () => {},
+      };
+    } else {
+      return {
+        next: nextTimer,
+        remove: () => {
+          this.timers.shift();
+        },
+      };
+    }
+  }
+
+  public now() {
+    if (this.currentFakeTime != null) {
+      return this.currentFakeTime;
+    } else {
+      return this.getMillisecond();
+    }
+  }
+
+  public enable() {
+    this.currentFakeTime = this.getMillisecond();
+    this.isUsingFakeTime = true;
+  }
+
+  public disable() {
+    this.currentFakeTime = null;
+    this.isUsingFakeTime = false;
   }
 
   public clear() {
     this.timers = [];
+    this.intervals = [];
   }
 
   public count() {
-    return this.timers.length;
+    return this.timers.length + this.intervals.length;
   }
 
   public addTimeout(
@@ -66,10 +168,16 @@ export class FakeTimerRegistry {
     ms: number | undefined,
     args: any[]
   ) {
-    const currentMillisecond = this.getMillisecond();
+    const currentMillisecond = this.now();
     const targetTime = currentMillisecond + (ms ?? 0);
 
-    const timer = new Timer(this.generateID(), callback, targetTime, args);
+    const timer = new Timer(
+      this,
+      this.generateID(),
+      callback,
+      targetTime,
+      args
+    );
     this.timers.push(timer);
     this.sortTimers();
     return timer;
@@ -79,33 +187,79 @@ export class FakeTimerRegistry {
     this.timers = this.timers.filter((t) => !t.is(id));
   }
 
+  public addInterval(
+    callback: (...args: any[]) => any,
+    ms: number | undefined,
+    args: any[]
+  ) {
+    const currentMillisecond = this.now();
+
+    const interval = new Interval(
+      this,
+      this.generateID(),
+      callback,
+      ms ?? 0,
+      args
+    );
+    this.intervals.push(interval);
+    this.sortIntervals();
+    return interval;
+  }
+
+  public cancelInterval(id: number) {
+    this.intervals = this.intervals.filter((t) => !t.is(id));
+  }
+
   public runAll() {
-    const allTimers = this.timers;
+    const toRun = this.timers.concat(this.intervals).sort(compareTimers);
     this.timers = [];
 
-    for (const timer of allTimers) {
-      try {
-        timer.run();
-      } catch (e) {
-        //
-      }
+    for (const timer of toRun) {
+      attempt(() => timer.run());
     }
   }
 
   public runNext(args?: any[]) {
-    const timer = this.timers.shift();
+    const timer = this.getNext();
 
     if (timer) {
-      return timer.run(args);
+      timer.remove();
+      return timer.next?.run(args);
+    }
+  }
+
+  public advanceBy(ms: number) {
+    if (this.currentFakeTime === null) {
+      return;
+    }
+
+    const currentMillisecond = this.currentFakeTime;
+    const targetTime = currentMillisecond + ms;
+    this.currentFakeTime = targetTime;
+
+    while (true) {
+      const timer = this.getNext();
+
+      if (!timer.next || timer.next.getTargetTime() > targetTime) {
+        break;
+      }
+
+      timer.remove();
+      attempt(() => timer.next!.run());
     }
   }
 }
 
-export const initFakeTimers = (console: ConsoleInterceptor) => {
-  const originalSetTimeout = setTimeout;
-  const originalSetInterval = setInterval;
+export const initFakeTimers = (
+  console: ConsoleInterceptor,
+  setGlobalValues = true
+) => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
 
-  const __gest_getSetTimeout = (container: GestTimers) => {
+  const setupFakeTimers = (container: GestTimers) => {
     const fakeTimerRegistry = new FakeTimerRegistry();
 
     Object.assign(container, {
@@ -139,38 +293,99 @@ export const initFakeTimers = (console: ConsoleInterceptor) => {
           }
         };
 
-        if (container.useFakeTimers) {
+        if (fakeTimerRegistry.isUsingFakeTime) {
           return fakeTimerRegistry.addTimeout(fn, ms, args).getID();
         } else {
-          const id = setTimeout(fn, ms, ...args);
-          return id;
+          return originalSetTimeout(fn, ms, ...args);
+        }
+      },
+      clearTimeout(id: number) {
+        if (fakeTimerRegistry.isUsingFakeTime) {
+          fakeTimerRegistry.cancelTimeout(id);
+        } else {
+          originalClearTimeout(id);
+        }
+      },
+      setInterval(
+        callback: (...args: any[]) => any,
+        ms?: number,
+        ...args: any[]
+      ) {
+        const error = new Error();
+
+        const handleError = (err: any) => {
+          console.error(
+            "Exception raised in a interval callback:",
+            err,
+            "\nThe above error was raised in this 'setInterval':",
+            error.stack && "\n  " + padLeftLines(error.stack, " ", 2)
+          );
+        };
+
+        const fn = (...fnArgs: any[]) => {
+          try {
+            const result = callback.apply(null, fnArgs);
+
+            if (result && result instanceof Promise) {
+              return result.catch(handleError);
+            }
+            return result;
+          } catch (err) {
+            handleError(err);
+          }
+        };
+
+        if (fakeTimerRegistry.isUsingFakeTime) {
+          return fakeTimerRegistry.addInterval(fn, ms, args).getID();
+        } else {
+          return originalSetInterval(fn, ms, ...args);
+        }
+      },
+      clearInterval(id: number) {
+        if (fakeTimerRegistry.isUsingFakeTime) {
+          fakeTimerRegistry.cancelInterval(id);
+        } else {
+          originalClearInterval(id);
         }
       },
     });
   };
 
-  Object.defineProperty(globalThis, "__gest_getSetTimeout", {
-    value: __gest_getSetTimeout,
-  });
+  if (setGlobalValues) {
+    Object.defineProperty(globalThis, "__gest_setupFakeTimers", {
+      value: setupFakeTimers,
+    });
 
-  Object.defineProperty(globalThis, "__gest_originalSetTimeout", {
-    value: originalSetTimeout,
-  });
+    Object.defineProperty(globalThis, "__gest_originalSetTimeout", {
+      value: originalSetTimeout,
+    });
 
-  Object.defineProperty(globalThis, "__gest_originalSetInterval", {
-    value: originalSetInterval,
-  });
+    Object.defineProperty(globalThis, "__gest_originalClearTimeout", {
+      value: originalClearTimeout,
+    });
+
+    Object.defineProperty(globalThis, "__gest_originalSetInterval", {
+      value: originalSetInterval,
+    });
+
+    Object.defineProperty(globalThis, "__gest_originalClearInterval", {
+      value: originalClearInterval,
+    });
+  }
+
+  return setupFakeTimers;
 };
 
 declare global {
-  const __gest_getSetTimeout:
+  const __gest_setupFakeTimers:
     | undefined
-    | ((container: { setTimeout: typeof setTimeout }) => void);
-
-  const __gest_getSetInterval:
-    | undefined
-    | ((container: { setInterval: typeof setInterval }) => void);
+    | ((container: {
+        setTimeout: typeof setTimeout;
+        setInterval: typeof setInterval;
+      }) => void);
 
   const __gest_originalSetTimeout: typeof setTimeout | undefined;
+  const __gest_originalClearTimeout: typeof clearTimeout | undefined;
   const __gest_originalSetInterval: typeof setInterval | undefined;
+  const __gest_originalClearInterval: typeof clearInterval | undefined;
 }

--- a/src/base/utils/timers.ts
+++ b/src/base/utils/timers.ts
@@ -192,8 +192,6 @@ export class FakeTimerRegistry {
     ms: number | undefined,
     args: any[]
   ) {
-    const currentMillisecond = this.now();
-
     const interval = new Interval(
       this,
       this.generateID(),

--- a/tests/user-land/fake-timers.test.ts
+++ b/tests/user-land/fake-timers.test.ts
@@ -1,0 +1,517 @@
+import { afterEach, beforeAll, describe, it, Mock } from "@reactgjs/gest";
+import { expect } from "gest";
+import { FakeTimerRegistry, initFakeTimers } from "../../src/base/utils/timers";
+
+const noop = (...args: any[]) => {};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default describe("FakeTimers", () => {
+  const timers = {
+    setTimeout: noop as any as typeof setTimeout,
+    clearTimeout: noop as any as typeof clearTimeout,
+    setInterval: noop as any as typeof setInterval,
+    clearInterval: noop as any as typeof clearInterval,
+    timeoutRegistry: null as FakeTimerRegistry | null,
+  };
+
+  class FakeTimersTest {
+    static enable() {
+      timers.timeoutRegistry?.enable();
+    }
+
+    static disable() {
+      timers.timeoutRegistry?.clear();
+      timers.timeoutRegistry?.disable();
+    }
+
+    static runAll() {
+      timers.timeoutRegistry?.runAll();
+    }
+
+    static runNext(args?: any[]): any {
+      return timers.timeoutRegistry?.runNext(args);
+    }
+
+    static advance(ms: number) {
+      timers.timeoutRegistry?.advanceBy(ms);
+    }
+
+    static isTimeoutStarted(times?: number) {
+      const c = timers.timeoutRegistry?.count() ?? 0;
+
+      if (times != null) {
+        return c === times;
+      } else {
+        return c > 0;
+      }
+    }
+  }
+
+  beforeAll(() => {
+    const setup = initFakeTimers(console as any, false);
+    setup(timers);
+    FakeTimersTest.enable();
+  });
+
+  afterEach(() => {
+    timers.timeoutRegistry?.clear();
+  });
+
+  describe("setTimeout", () => {
+    describe("with a single timeout", () => {
+      it("should not execute", async () => {
+        const mock = Mock.create(() => {});
+
+        timers.setTimeout(mock.fn, 100);
+
+        await sleep(500);
+
+        expect(mock).not.toHaveBeenCalled();
+      });
+
+      it("should execute after runNext", () => {
+        const mock = Mock.create(() => {});
+
+        timers.setTimeout(mock.fn, 100);
+
+        FakeTimersTest.runNext();
+
+        expect(mock).toHaveBeenCalled(1);
+      });
+
+      it("should execute after runAll", async () => {
+        const mock = Mock.create(() => {});
+
+        timers.setTimeout(mock.fn, 100);
+
+        FakeTimersTest.runAll();
+
+        expect(mock).toHaveBeenCalled(1);
+      });
+
+      it("should execute after advance", async () => {
+        const mock = Mock.create(() => {});
+
+        timers.setTimeout(mock.fn, 100);
+
+        FakeTimersTest.advance(25);
+
+        expect(mock).not.toHaveBeenCalled();
+
+        FakeTimersTest.advance(50);
+
+        expect(mock).not.toHaveBeenCalled();
+
+        FakeTimersTest.advance(24);
+
+        expect(mock).not.toHaveBeenCalled();
+
+        FakeTimersTest.advance(1);
+
+        expect(mock).toHaveBeenCalled(1);
+      });
+    });
+
+    describe("with multiple timeouts", () => {
+      it("should respect the ms values", async () => {
+        const mock1 = Mock.create(() => {});
+        const mock2 = Mock.create(() => {});
+        const mock3 = Mock.create(() => {});
+
+        timers.setTimeout(mock1.fn, 100);
+        timers.setTimeout(mock2.fn, 200);
+        timers.setTimeout(mock3.fn, 300);
+
+        FakeTimersTest.advance(150);
+
+        expect(mock1).toHaveBeenCalled(1);
+        expect(mock2).not.toHaveBeenCalled();
+        expect(mock3).not.toHaveBeenCalled();
+
+        FakeTimersTest.advance(100);
+
+        expect(mock1).toHaveBeenCalled(1);
+        expect(mock2).toHaveBeenCalled(1);
+        expect(mock3).not.toHaveBeenCalled();
+
+        FakeTimersTest.advance(100);
+
+        expect(mock1).toHaveBeenCalled(1);
+        expect(mock2).toHaveBeenCalled(1);
+        expect(mock3).toHaveBeenCalled(1);
+      });
+
+      it("should execute in the correct order", async () => {
+        const mock1 = Mock.create(() => {});
+        const mock2 = Mock.create(() => {});
+        const mock3 = Mock.create(() => {});
+        const mock4 = Mock.create(() => {});
+
+        timers.setTimeout(mock1.fn, 100);
+        timers.setTimeout(mock2.fn, 50);
+        timers.setTimeout(mock3.fn, 20);
+        timers.setTimeout(mock4.fn, 70);
+
+        FakeTimersTest.advance(25);
+
+        expect(mock1).not.toHaveBeenCalled();
+        expect(mock2).not.toHaveBeenCalled();
+        expect(mock3).toHaveBeenCalled(1);
+        expect(mock4).not.toHaveBeenCalled();
+
+        FakeTimersTest.advance(25);
+
+        expect(mock1).not.toHaveBeenCalled();
+        expect(mock2).toHaveBeenCalled(1);
+        expect(mock3).toHaveBeenCalled(1);
+        expect(mock4).not.toHaveBeenCalled();
+
+        FakeTimersTest.advance(25);
+
+        expect(mock1).not.toHaveBeenCalled();
+        expect(mock2).toHaveBeenCalled(1);
+        expect(mock3).toHaveBeenCalled(1);
+        expect(mock4).toHaveBeenCalled(1);
+
+        FakeTimersTest.advance(25);
+
+        expect(mock1).toHaveBeenCalled(1);
+        expect(mock2).toHaveBeenCalled(1);
+        expect(mock3).toHaveBeenCalled(1);
+        expect(mock4).toHaveBeenCalled(1);
+      });
+
+      it("should execute in the correct order when many are ran at once", () => {
+        const order: number[] = [];
+
+        const mock1 = Mock.create(() => {
+          order.push(1);
+        });
+        const mock2 = Mock.create(() => {
+          order.push(2);
+        });
+        const mock3 = Mock.create(() => {
+          order.push(3);
+        });
+        const mock4 = Mock.create(() => {
+          order.push(4);
+        });
+
+        timers.setTimeout(mock1.fn, 100);
+        timers.setTimeout(mock2.fn, 50);
+        timers.setTimeout(mock3.fn, 20);
+        timers.setTimeout(mock4.fn, 70);
+
+        FakeTimersTest.advance(100);
+
+        expect(order).toEqual([3, 2, 4, 1]);
+      });
+    });
+  });
+
+  describe("clearTimeout", () => {
+    it("should clear the timeout", async () => {
+      const mock = Mock.create(() => {});
+
+      const id = timers.setTimeout(mock.fn, 100);
+
+      timers.clearTimeout(id);
+
+      FakeTimersTest.advance(100);
+
+      expect(mock).not.toHaveBeenCalled();
+    });
+
+    it("should clear the timeout when multiple are set", async () => {
+      const mock1 = Mock.create(() => {});
+      const mock2 = Mock.create(() => {});
+      const mock3 = Mock.create(() => {});
+
+      timers.setTimeout(mock1.fn, 100);
+      const id2 = timers.setTimeout(mock2.fn, 200);
+      timers.setTimeout(mock3.fn, 300);
+
+      timers.clearTimeout(id2);
+
+      FakeTimersTest.advance(1000);
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).not.toHaveBeenCalled();
+      expect(mock3).toHaveBeenCalled(1);
+    });
+  });
+
+  describe("setInterval", () => {
+    it("should not execute", async () => {
+      const mock = Mock.create(() => {});
+
+      timers.setInterval(mock.fn, 100);
+
+      await sleep(500);
+
+      expect(mock).not.toHaveBeenCalled();
+    });
+
+    it("should execute after each runNext", () => {
+      const mock = Mock.create(() => {});
+
+      timers.setInterval(mock.fn, 100);
+
+      FakeTimersTest.runNext();
+      expect(mock).toHaveBeenCalled(1);
+
+      FakeTimersTest.runNext();
+      expect(mock).toHaveBeenCalled(2);
+
+      FakeTimersTest.runNext();
+      expect(mock).toHaveBeenCalled(3);
+    });
+
+    it("should execute after each runAll", async () => {
+      const mock = Mock.create(() => {});
+
+      timers.setInterval(mock.fn, 100);
+
+      FakeTimersTest.runAll();
+      expect(mock).toHaveBeenCalled(1);
+
+      FakeTimersTest.runAll();
+      expect(mock).toHaveBeenCalled(2);
+
+      FakeTimersTest.runAll();
+      expect(mock).toHaveBeenCalled(3);
+    });
+
+    it("should execute after each fitting advance", async () => {
+      const mock = Mock.create(() => {});
+
+      timers.setInterval(mock.fn, 100);
+
+      FakeTimersTest.advance(25);
+      expect(mock).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(50);
+      expect(mock).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(24);
+      expect(mock).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(1);
+      expect(mock).toHaveBeenCalled(1);
+
+      FakeTimersTest.advance(25);
+      expect(mock).toHaveBeenCalled(1);
+
+      FakeTimersTest.advance(75);
+      expect(mock).toHaveBeenCalled(2);
+
+      FakeTimersTest.advance(100);
+      expect(mock).toHaveBeenCalled(3);
+    });
+
+    it("should execute the interval multiple times when advancing by a large amount", async () => {
+      const mock = Mock.create(() => {});
+
+      timers.setInterval(mock.fn, 100);
+
+      FakeTimersTest.advance(1000);
+
+      expect(mock).toHaveBeenCalled(10);
+    });
+  });
+
+  describe("clearInterval", () => {
+    it("should clear the interval", async () => {
+      const mock = Mock.create(() => {});
+
+      const id = timers.setInterval(mock.fn, 100);
+
+      timers.clearInterval(id);
+
+      FakeTimersTest.advance(100);
+
+      expect(mock).not.toHaveBeenCalled();
+    });
+
+    it("should clear the interval when multiple are set", async () => {
+      const mock1 = Mock.create(() => {});
+      const mock2 = Mock.create(() => {});
+      const mock3 = Mock.create(() => {});
+
+      timers.setInterval(mock1.fn, 100);
+      const id2 = timers.setInterval(mock2.fn, 200);
+      timers.setInterval(mock3.fn, 300);
+
+      timers.clearInterval(id2);
+
+      FakeTimersTest.advance(1000);
+
+      expect(mock1).toHaveBeenCalled(10);
+      expect(mock2).not.toHaveBeenCalled();
+      expect(mock3).toHaveBeenCalled(3);
+    });
+  });
+
+  describe("mixing many different scenarios", () => {
+    it("should work correctly when advancing one by one", () => {
+      const mock1 = Mock.create(() => {});
+      const mock2 = Mock.create(() => {});
+      const mock3 = Mock.create(() => {});
+      const mock4 = Mock.create(() => {});
+      const mock5 = Mock.create(() => {});
+      const mock6 = Mock.create(() => {});
+      const mock7 = Mock.create(() => {});
+      const mock8 = Mock.create(() => {});
+
+      timers.setTimeout(mock1.fn, 100);
+      timers.setInterval(mock2.fn, 100);
+      const t3id = timers.setTimeout(mock3.fn, 200);
+      const t4id = timers.setInterval(mock4.fn, 200);
+      timers.setTimeout(mock5.fn, 300);
+      timers.setInterval(mock6.fn, 350);
+      timers.setTimeout(mock7.fn, 400);
+      timers.setInterval(mock8.fn, 500);
+
+      FakeTimersTest.advance(99);
+
+      expect(mock1).not.toHaveBeenCalled();
+      expect(mock2).not.toHaveBeenCalled();
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).not.toHaveBeenCalled();
+      expect(mock6).not.toHaveBeenCalled();
+      expect(mock7).not.toHaveBeenCalled();
+      expect(mock8).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(51); // 151
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(1);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).not.toHaveBeenCalled();
+      expect(mock6).not.toHaveBeenCalled();
+      expect(mock7).not.toHaveBeenCalled();
+      expect(mock8).not.toHaveBeenCalled();
+
+      timers.clearTimeout(t3id);
+      timers.clearInterval(t4id);
+
+      FakeTimersTest.advance(100); // 251
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(2);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).not.toHaveBeenCalled();
+      expect(mock6).not.toHaveBeenCalled();
+      expect(mock7).not.toHaveBeenCalled();
+      expect(mock8).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(50); // 301
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(3);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).toHaveBeenCalled(1);
+      expect(mock6).not.toHaveBeenCalled();
+      expect(mock7).not.toHaveBeenCalled();
+      expect(mock8).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(50); // 350
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(3);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).toHaveBeenCalled(1);
+      expect(mock6).toHaveBeenCalled(1);
+      expect(mock7).not.toHaveBeenCalled();
+      expect(mock8).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(50); // 400
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(4);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).toHaveBeenCalled(1);
+      expect(mock6).toHaveBeenCalled(1);
+      expect(mock7).toHaveBeenCalled(1);
+      expect(mock8).not.toHaveBeenCalled();
+
+      FakeTimersTest.advance(150); // 550
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(5);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).toHaveBeenCalled(1);
+      expect(mock6).toHaveBeenCalled(1);
+      expect(mock7).toHaveBeenCalled(1);
+      expect(mock8).toHaveBeenCalled(1);
+
+      FakeTimersTest.advance(150); // 700
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(7);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).toHaveBeenCalled(1);
+      expect(mock6).toHaveBeenCalled(2);
+      expect(mock7).toHaveBeenCalled(1);
+      expect(mock8).toHaveBeenCalled(1);
+
+      FakeTimersTest.advance(300); // 1000
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(10);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).toHaveBeenCalled(1);
+      expect(mock6).toHaveBeenCalled(2);
+      expect(mock7).toHaveBeenCalled(1);
+      expect(mock8).toHaveBeenCalled(2);
+    });
+
+    it("should work correctly when advancing by a large amount", () => {
+      const order: number[] = [];
+
+      const mock1 = Mock.create(() => order.push(1));
+      const mock2 = Mock.create(() => order.push(2));
+      const mock3 = Mock.create(() => order.push(3));
+      const mock4 = Mock.create(() => order.push(4));
+      const mock5 = Mock.create(() => order.push(5));
+      const mock6 = Mock.create(() => order.push(6));
+      const mock7 = Mock.create(() => order.push(7));
+      const mock8 = Mock.create(() => order.push(8));
+
+      timers.setTimeout(mock1.fn, 100);
+      timers.setInterval(mock2.fn, 100);
+      const t3id = timers.setTimeout(mock3.fn, 200);
+      const t4id = timers.setInterval(mock4.fn, 200);
+      timers.setTimeout(mock5.fn, 300);
+      timers.setInterval(mock6.fn, 350);
+      timers.setTimeout(mock7.fn, 400);
+      timers.setInterval(mock8.fn, 500);
+
+      timers.clearTimeout(t3id);
+      timers.clearInterval(t4id);
+
+      FakeTimersTest.advance(700);
+
+      expect(mock1).toHaveBeenCalled(1);
+      expect(mock2).toHaveBeenCalled(7);
+      expect(mock3).not.toHaveBeenCalled();
+      expect(mock4).not.toHaveBeenCalled();
+      expect(mock5).toHaveBeenCalled(1);
+      expect(mock6).toHaveBeenCalled(2);
+      expect(mock7).toHaveBeenCalled(1);
+      expect(mock8).toHaveBeenCalled(1);
+
+      expect(order).toEqual([1, 2, 2, 5, 2, 6, 7, 2, 2, 8, 2, 2, 6]);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,14 +460,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@reactgjs/gest@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@reactgjs/gest/-/gest-0.1.1.tgz#e0c88271323d470572a9e76cb9679a20ecfd494d"
-  integrity sha512-O8JO56QBP9a4eQ5s0xOkFv7w3mt/Mmh/0MY9JtMMhL/BlNdxVni9DVW8Tcfw19pQ2EVQyt5bYzqB2uGJ/z3DOg==
+"@reactgjs/gest@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@reactgjs/gest/-/gest-0.3.2.tgz#15bdb1b4d521fb06623fb1ef653a6451e8c5f711"
+  integrity sha512-q/L5OcFHyQ1LdRLr702dL4pPkxcHfC1LQ+cqV4fvVU/yqkjsL3lCVcDjHC14/3dK8pAENRpD09bXi/ZwRi2DWQ==
   dependencies:
-    dilswer "^2.0.2"
     esbuild "^0.17.17"
-    termx-markup "^1.1.0"
 
 "@ts-morph/bootstrap@^0.20.0":
   version "0.20.0"
@@ -789,7 +787,7 @@ clify.js@ncpa0cpl/clify.js:
   dependencies:
     chalk "^4.1.2"
 
-"clify@github:ncpa0cpl/clify.js#0.0.4":
+clify@ncpa0cpl/clify.js#0.0.4:
   version "1.0.3"
   resolved "https://codeload.github.com/ncpa0cpl/clify.js/tar.gz/fe91dede1322b302fbc7ca8f5695ce37ccfb8bf4"
   dependencies:
@@ -2508,6 +2506,7 @@ string-at@^1.0.1:
     es-abstract "^1.17.0-next.1"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
FakeTimers although present in the previous version, were incomplete. Only the `setTimeout` was being mocked when using them, and it was impossible to clear fake timeouts, advancing the timers by an arbitrary amount was also not possible.

All that has changed, `setInterval` is now also mocked when using FakeTimers, clearing the mocked timers should also work, and a new method has been added to the FakeTimers api: `advance()` which will run all pending timers that would have been scheduled within the timeframe of when they were initiated and N milliseconds after that, whereas N is provided to the advance function.