### PR TITLE
fix: toEqual bug with arrays

### DIFF
--- a/src/user-land/utils/validators.ts
+++ b/src/user-land/utils/validators.ts
@@ -31,6 +31,8 @@ export function deepEqual(a: any, b: any): EqualityCheck {
 
   if (Array.isArray(a) && Array.isArray(b)) {
     const lastAIndex = a.length - 1;
+    const lastBIndex = b.length - 1;
+
     for (const bIndex of b.keys()) {
       if (bIndex > lastAIndex) {
         return {
@@ -48,6 +50,22 @@ export function deepEqual(a: any, b: any): EqualityCheck {
       if (!result.isEqual) {
         return result;
       }
+    }
+
+    if (lastAIndex > lastBIndex) {
+      return {
+        isEqual: false,
+        expected: undefined,
+        received: a[lastBIndex + 1],
+      };
+    }
+
+    if (a.length !== b.length) {
+      return {
+        isEqual: false,
+        expected: b,
+        received: a,
+      };
     }
 
     return {


### PR DESCRIPTION
Fixed a bug in the comparison algorithm used in the `expect.toEqual()` and `match.equal()` functions. The bug was causing the assertion to pass in situations where the expected array was shorter than the tested array. That was not intentional since the equalision comparison is supposed to assert objects to be strictly equal to each other.

### Example

```ts
// old behavior
expect([1, 2, 3]).toEqual([]); // passes

// new, fixed behavior
expect([1, 2, 3]).toEqual([]); // fails with: "ExpectError: Deep equality test has failed. Expected: undefined Received: 1"
```