### PR TITLE
refactor: use esbuild's banner option, instead of prepending output file

### DIFF
--- a/src/base/builder/esbuild-script.ts
+++ b/src/base/builder/esbuild-script.ts
@@ -196,6 +196,11 @@ async function main() {
       await loadSetup(msg.setup.secondary);
     }
 
+    const fileBanner = await fs.readFile(
+      path.join(__dirname, "injects.mjs"),
+      "utf-8"
+    );
+
     await esbuild.build({
       target: "es2022",
       entryPoints: [msg.input],
@@ -206,6 +211,9 @@ async function main() {
       minify: false,
       keepNames: true,
       sourcemap: true,
+      banner: {
+        js: fileBanner,
+      },
       plugins: [
         {
           name: "gest-import-replacer",
@@ -231,14 +239,6 @@ async function main() {
         },
       ],
     });
-
-    const out = await fs.readFile(msg.output, "utf-8");
-    const injects = await fs.readFile(
-      path.join(__dirname, "injects.mjs"),
-      "utf-8"
-    );
-
-    await fs.writeFile(msg.output, injects + "\n" + out, "utf-8");
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/src/base/globals.ts
+++ b/src/base/globals.ts
@@ -1,7 +1,6 @@
 export class Global {
   private static cwd?: string;
   private static tmpDir?: string;
-  private static sourceMapLineOffset?: number;
 
   public static getCwd(): string {
     if (!this.cwd) {
@@ -25,17 +24,5 @@ export class Global {
 
   public static setTmpDir(tmpDir: string): void {
     this.tmpDir = tmpDir;
-  }
-
-  public static getSourceMapLineOffset(): number {
-    if (!this.sourceMapLineOffset) {
-      throw new Error("Source map offset not set.");
-    }
-
-    return this.sourceMapLineOffset;
-  }
-
-  public static setSourceMapLineOffset(offset: number): void {
-    this.sourceMapLineOffset = offset;
   }
 }

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -75,12 +75,6 @@ async function main() {
 
     const _dirname = getDirname(import.meta.url);
 
-    const injectsFilepath = path.resolve(_dirname, "./builder/injects.mjs");
-    const injectsFile = await Fs.readTextFile(injectsFilepath);
-    const injectsLines = injectsFile.split("\n");
-
-    Global.setSourceMapLineOffset(injectsLines.length);
-
     let tmpDir = path.join(_dirname, "_tmp");
     if (tmpDir.includes("/node_modules/")) {
       while (true) {

--- a/src/base/progress/progress-utils/suite-progress.ts
+++ b/src/base/progress/progress-utils/suite-progress.ts
@@ -59,10 +59,7 @@ export class SuiteProgress {
   }
 
   private getHookLink(sourceMap: SourceMapReader, hook: TestHook) {
-    const hookLocation = sourceMap.getOriginalPosition(
-      hook.line - Global.getSourceMapLineOffset(),
-      hook.column
-    );
+    const hookLocation = sourceMap.getOriginalPosition(hook.line, hook.column);
 
     if (hookLocation == null) return undefined;
 

--- a/src/base/progress/progress-utils/unit-progress.ts
+++ b/src/base/progress/progress-utils/unit-progress.ts
@@ -1,5 +1,4 @@
 import type { Test } from "../../../user-land/test-collector";
-import { Global } from "../../globals";
 import type { SourceMapReader } from "../../sourcemaps/reader";
 import type { ConfigFacade } from "../../utils/config";
 import {
@@ -69,7 +68,7 @@ export class UnitProgress {
     if (this.unit == null || !sourceMap) return undefined;
 
     const unitLocation = sourceMap.getOriginalPosition(
-      this.unit.line - Global.getSourceMapLineOffset(),
+      this.unit.line,
       this.unit.column
     );
 
@@ -85,7 +84,7 @@ export class UnitProgress {
     location: { file: string; line: number; column: number }
   ) {
     const expectLocation = sourceMap.getOriginalPosition(
-      location.line - Global.getSourceMapLineOffset(),
+      location.line,
       location.column
     );
 

--- a/src/base/utils/errors/error-handling.ts
+++ b/src/base/utils/errors/error-handling.ts
@@ -3,7 +3,6 @@ import type {
   ExpectError,
   GestTestError,
 } from "../../../user-land/utils/errors";
-import { Global } from "../../globals";
 import type { SourceMapReader } from "../../sourcemaps/reader";
 import type { ConfigFacade } from "../config";
 import type { ParsedStack } from "../error-stack-parser-type";
@@ -69,7 +68,7 @@ export function _getErrorStack(
 
         if (stackItem.line != null && stackItem.column != null) {
           const mapped = sourceMap.getOriginalPosition(
-            Number(stackItem.line) - Global.getSourceMapLineOffset(),
+            Number(stackItem.line),
             Number(stackItem.column)
           );
 


### PR DESCRIPTION
To inject some code into the build files of the test files, gest was simply writing to the output files via an `fs` function. This meant that it also had to take an offset when resolving source maps (since changing the content of the output means breaking compatibility with the source map of that file). To avoid this additional complexity gest now will use the `banner` option from `esbuild` instead. This option will inject the text into the file (as it worked before) but keep the sourcemaps valid, so keeping track of the offset and applying it won't be needed anymore.