### PR TITLE
feat: config option for specifying gi libs versions

### DIFF
--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -19,6 +19,7 @@ import {
 import { walkFiles } from "./utils/filesystem";
 import { getDirname } from "./utils/get-dirname";
 import path from "./utils/path";
+import { preloadGiLibs } from "./utils/preload-gi-libs";
 import { initFakeTimers } from "./utils/timers";
 
 declare global {
@@ -113,6 +114,8 @@ async function main() {
     if (!config) {
       return Mainloop.exit(1);
     }
+
+    await preloadGiLibs(config);
 
     const testsDir = path.resolve(Global.getCwd(), config.testDir);
     const parallel = config.parallel;

--- a/src/base/utils/config-schema.ts
+++ b/src/base/utils/config-schema.ts
@@ -1,4 +1,7 @@
-import type { ParseToJsonSchemaOptions, TsParsingOptions } from "dilswer";
+import type {
+  ParseToJsonSchemaOptions,
+  TsParsingOptions,
+} from "dilswer";
 import { OptionalField, Type, toJsonSchema, toTsType } from "dilswer";
 import { BaseReporter } from "../progress/base-reporter";
 
@@ -28,66 +31,92 @@ export const ConfigSchema = Type.RecordOf({
       Type.Boolean,
       Type.String,
       Type.ArrayOf(Type.Unknown),
-      Type.RecordOf({})
-    )
+      Type.RecordOf({}),
+    ),
+  ),
+  introspectedLibVersion: OptionalField(
+    Type.RecordOf({
+      atk: OptionalField(Type.String),
+      gmodule: OptionalField(Type.String),
+      gobject: OptionalField(Type.String),
+      gdk: OptionalField(Type.String),
+      gdkPixbuf: OptionalField(Type.String),
+      graphene: OptionalField(Type.String),
+      gsk: OptionalField(Type.String),
+      gtk: OptionalField(Type.String),
+      harfbuzz: OptionalField(Type.String),
+      pango: OptionalField(Type.String),
+      pangoCairo: OptionalField(Type.String),
+      soup: OptionalField(Type.String),
+      cairo: OptionalField(Type.String),
+      xlib: OptionalField(Type.String),
+    }),
   ),
   errorReporterParser: OptionalField(
     Type.Function.setExtra({
       typeName: "ErrorReporterParser",
       path: "./error-reporter-parser-type",
-    })
+    }),
   ),
   errorStackParser: OptionalField(
     Type.Function.setExtra({
       typeName: "ErrorStackParser",
       path: "./error-stack-parser-type",
-    })
+    }),
   ),
-  reporters: OptionalField(Type.ArrayOf(Type.Literal("default"), ReporterType)),
+  reporters: OptionalField(
+    Type.ArrayOf(Type.Literal("default"), ReporterType),
+  ),
 });
 
 ConfigSchema.setTitle("Config");
 
 export const generateConfigSchema = (
-  options?: ParseToJsonSchemaOptions | undefined
+  options?: ParseToJsonSchemaOptions | undefined,
 ) => {
   return toJsonSchema(ConfigSchema, options);
 };
 
-export const generateConfigType = (options?: Partial<TsParsingOptions>) => {
+export const generateConfigType = (
+  options?: Partial<TsParsingOptions>,
+) => {
   return toTsType(ConfigSchema, options);
 };
 
 // Config options description
 
 ConfigSchema.recordOf.defaultTimeoutThreshold.type.setDescription(
-  "Default timeout threshold for tests in milliseconds. If any test takes longer than this threshold, it will fail. Default value is 5000ms."
+  "Default timeout threshold for tests in milliseconds. If any test takes longer than this threshold, it will fail. Default value is 5000ms.",
 );
 
 ConfigSchema.recordOf.parallel.type.setDescription(
-  "Defines how many test Suites can be ran in parallel. Although currently all tests are always ran on a single thread, meaning this option will mostly only affect tests that are heavily asynchronous. Defaults to `2`."
+  "Defines how many test Suites can be ran in parallel. Although currently all tests are always ran on a single thread, meaning this option will mostly only affect tests that are heavily asynchronous. Defaults to `2`.",
 );
 
 ConfigSchema.recordOf.srcDir.type.setDescription(
-  "Directory where your source files are located. (module mocks should be defined as filepaths relative to this dir) Default is the current directory."
+  "Directory where your source files are located. (module mocks should be defined as filepaths relative to this dir) Default is the current directory.",
 );
 
 ConfigSchema.recordOf.testDir.type.setDescription(
-  "The directory where the test files are located. Defaults to `./__tests__`."
+  "The directory where the test files are located. Defaults to `./__tests__`.",
 );
 
 ConfigSchema.recordOf.setup.type.setDescription(
-  "Path to a setup file that can contain module mock's import maps."
+  "Path to a setup file that can contain module mock's import maps.",
 );
 
 ConfigSchema.recordOf.globals.type.setDescription(
-  "Global variables that will be available to all tests."
+  "Global variables that will be available to all tests.",
+);
+
+ConfigSchema.recordOf.introspectedLibVersion.type.setDescription(
+  "Specify the default version for the given libraries imported via the GObject Introspection (`gi`).\n\n`GLib` and `Gio` versions cannot be changed, since gest is dependant on those.",
 );
 
 ConfigSchema.recordOf.errorReporterParser.type.setDescription(
-  "A function that allows to modify and customize the error messages that are printed in the console output when running tests.\n\nEach Error intercepted during a test run will be passed to this function along with the message that would be printed by default. The returned string will be printed as the error message instead."
+  "A function that allows to modify and customize the error messages that are printed in the console output when running tests.\n\nEach Error intercepted during a test run will be passed to this function along with the message that would be printed by default. The returned string will be printed as the error message instead.",
 );
 
 ConfigSchema.recordOf.reporters.type.setDescription(
-  "An array of reporters to use. Default is `['default']`."
+  "An array of reporters to use. Default is `['default']`.",
 );

--- a/src/base/utils/config.ts
+++ b/src/base/utils/config.ts
@@ -56,15 +56,23 @@ class ConfigFacade {
   }
 
   get setup() {
-    return this.config.setup;
+    return this.get("setup");
+  }
+
+  get introspectedLibVersion() {
+    return this.get("introspectedLibVersion");
   }
 
   get errorReporterParser() {
-    return this.get("errorReporterParser") as ErrorReporterParser | undefined;
+    return this.get("errorReporterParser") as
+      | ErrorReporterParser
+      | undefined;
   }
 
   get errorStackParser() {
-    return this.get("errorStackParser") as ErrorStackParser | undefined;
+    return this.get("errorStackParser") as
+      | ErrorStackParser
+      | undefined;
   }
 }
 
@@ -76,13 +84,18 @@ export type ConfigContext = {
   importModule: <T>(module: string) => Promise<T>;
 };
 
-export type ConfigGetter = (context: ConfigContext) => Promise<Config> | Config;
+export type ConfigGetter = (
+  context: ConfigContext,
+) => Promise<Config> | Config;
 
-export async function loadConfig(vargs: string[], options: TestRunnerOptions) {
+export async function loadConfig(
+  vargs: string[],
+  options: TestRunnerOptions,
+) {
   const files = await Fs.listFilenames(Global.getCwd());
 
   const jsTypeConfig = files.find((filename) =>
-    /gest\.config\.(js|mjs)$/i.test(filename)
+    /gest\.config\.(js|mjs)$/i.test(filename),
   );
 
   if (jsTypeConfig) {
@@ -105,20 +118,22 @@ export async function loadConfig(vargs: string[], options: TestRunnerOptions) {
       return new ConfigFacade(config);
     } catch (e) {
       if (!configLoaded) {
-        Output.print(
-          html`
-            <line color="yellow">
-              Unable to get the config. Error ocurred in:
-            </line>
-            <line color="cyan">${configFilePath}</line>
-            <pad size="2"><pre>${String(e)}</pre></pad>
-          `
-        );
+        Output.print(html`
+          <line color="yellow">
+            Unable to get the config. Error ocurred in:
+          </line>
+          <line color="cyan">${configFilePath}</line>
+          <pad size="2"><pre>${String(e)}</pre></pad>
+        `);
       } else {
-        Output.print(html`<span color="yellow"> Invalid config file. </span>`);
+        Output.print(
+          html`<span color="yellow"> Invalid config file. </span>`,
+        );
 
         if (ValidationError.isValidationError(e)) {
-          Output.print(html`<pre>  Invalid value at: ${e.fieldPath}</pre>`);
+          Output.print(
+            html`<pre>  Invalid value at: ${e.fieldPath}</pre>`,
+          );
         }
       }
 
@@ -130,7 +145,7 @@ export async function loadConfig(vargs: string[], options: TestRunnerOptions) {
 
   if (files.includes("gest.config.json")) {
     const configText = await Fs.readTextFile(
-      path.join(Global.getCwd(), "gest.config.json")
+      path.join(Global.getCwd(), "gest.config.json"),
     );
     const config = JSON.parse(configText);
 
@@ -138,10 +153,14 @@ export async function loadConfig(vargs: string[], options: TestRunnerOptions) {
       assertDataType(ConfigSchema, config);
       return new ConfigFacade(config);
     } catch (e) {
-      Output.print(html`<span color="yellow"> Invalid config file. </span>`);
+      Output.print(
+        html`<span color="yellow"> Invalid config file. </span>`,
+      );
 
       if (ValidationError.isValidationError(e)) {
-        Output.print(html`<pre>  Invalid value at: ${e.fieldPath}</pre>`);
+        Output.print(
+          html`<pre>  Invalid value at: ${e.fieldPath}</pre>`,
+        );
       }
 
       Output.print("");
@@ -153,7 +172,7 @@ export async function loadConfig(vargs: string[], options: TestRunnerOptions) {
   Output.print(
     html`<span color="yellow">
       Config file not found. Using default config instead.
-    </span>`
+    </span>`,
   );
   return new ConfigFacade({});
 }

--- a/src/base/utils/preload-gi-libs.ts
+++ b/src/base/utils/preload-gi-libs.ts
@@ -1,0 +1,63 @@
+import type { ConfigFacade } from "./config";
+
+export const preloadGiLibs = async (config: ConfigFacade) => {
+  if (config.introspectedLibVersion) {
+    const v = config.introspectedLibVersion;
+
+    if (v.atk) {
+      await import("gi://Atk?version=" + v.atk);
+    }
+
+    if (v.gmodule) {
+      await import("gi://GModule?version=" + v.gmodule);
+    }
+
+    if (v.gobject) {
+      await import("gi://GObject?version=" + v.gobject);
+    }
+
+    if (v.gdk) {
+      await import("gi://Gdk?version=" + v.gdk);
+    }
+
+    if (v.gdkPixbuf) {
+      await import("gi://GdkPixbuf?version=" + v.gdkPixbuf);
+    }
+
+    if (v.graphene) {
+      await import("gi://Graphene?version=" + v.graphene);
+    }
+
+    if (v.gsk) {
+      await import("gi://Gsk?version=" + v.gsk);
+    }
+
+    if (v.gtk) {
+      await import("gi://Gtk?version=" + v.gtk);
+    }
+
+    if (v.harfbuzz) {
+      await import("gi://Harfbuzz?version=" + v.harfbuzz);
+    }
+
+    if (v.pango) {
+      await import("gi://Pango?version=" + v.pango);
+    }
+
+    if (v.pangoCairo) {
+      await import("gi://PangoCairo?version=" + v.pangoCairo);
+    }
+
+    if (v.soup) {
+      await import("gi://Soup?version=" + v.soup);
+    }
+
+    if (v.cairo) {
+      await import("gi://Cairo?version=" + v.cairo);
+    }
+
+    if (v.xlib) {
+      await import("gi://Xlib?version=" + v.xlib);
+    }
+  }
+};


### PR DESCRIPTION
Added a new config option `introspectedLibVersion`. This option can accept version numbers for libraries like `Gdk`, `Atk`, etc. All tests will be ran in environment with these libraries with that version loaded.